### PR TITLE
Update regex for amount extraction to support single digit decimals

### DIFF
--- a/lib/src/utils/extract_axis.dart
+++ b/lib/src/utils/extract_axis.dart
@@ -6,9 +6,9 @@ Iterable<Transaction> extractAxisMessages(
     .map((message) {
       RegExp typeRegex = RegExp(r'(credited|Debit|Spent)');
       RegExp debitTypeRegex = RegExp(r'(UPI/|ATM-WDL/)');
-      RegExp amountRegex = RegExp(r'INR (\d+(\.\d{2})?)');
+      RegExp amountRegex = RegExp(r'INR (\d+(?:\.\d{1,2})?)');
       RegExp finalAmountRegex = RegExp(
-        r'(Avl Bal-|Bal|Avl Lmt) INR (\d+(\.\d{2})?)',
+        r'(Avl Bal-|Bal|Avl Lmt) INR (\d+(?:\.\d{1,2})?)',
       );
       RegExp accountNumberRegex = RegExp(r'(A/c no|Card no)\. XX(\d+)');
       RegExp dateTimeRegex = RegExp(

--- a/lib/src/utils/extract_bob.dart
+++ b/lib/src/utils/extract_bob.dart
@@ -5,7 +5,7 @@ Iterable<Transaction> extractBOBMessages(
 ) => bobMessages
     .map((message) {
       RegExp typeRegex = RegExp(r'(Credited|withdrawn|transferred)');
-      RegExp amountRegex = RegExp(r'Rs\.([\d,]+(?:\.\d{2})?)');
+      RegExp amountRegex = RegExp(r'Rs\.([\d,]+(?:\.\d{1,2})?)');
       RegExp finalAmountRegex = RegExp(r'Avlbl Amt:Rs\.([\d,]+(?:\.\d{1,2})?)');
       RegExp accountNumberRegex = RegExp(r'A/c \.{3}(\d+)');
       RegExp dateTimeRegex = RegExp(

--- a/lib/src/utils/extract_cosmos.dart
+++ b/lib/src/utils/extract_cosmos.dart
@@ -4,9 +4,9 @@ Iterable<Transaction> extractCosmosMessages(Iterable<String> bobMessages) =>
     bobMessages
         .map((message) {
           RegExp typeRegex = RegExp(r'(debited|credited)');
-          RegExp amountRegex = RegExp(r'INR\.? ([\d,]+(?:\.\d{2})?)');
+          RegExp amountRegex = RegExp(r'INR\.? ([\d,]+(?:\.\d{1,2})?)');
           RegExp finalAmountRegex = RegExp(
-            r'A/c (balance is INR|bal is INR)\.? (\d+\.\d+)',
+            r'A/c (balance is INR|bal is INR)\.? (\d+(?:\.\d{1,2})?)',
           );
 
           RegExp accountNumberRegex = RegExp(r'A/c (no )?X{1,2}(\d+)');

--- a/test/extract_test.dart
+++ b/test/extract_test.dart
@@ -122,4 +122,34 @@ void main() {
       expect(transaction.dateTime, DateTime.parse('2023-11-23 00:00:00'));
     });
   });
+
+  group('Defect #10: Single digit after decimal', () {
+    test('BOB single digit decimal', () {
+      var transaction = extractBOBMessages([bobMessages.last]).first;
+      expect(transaction.type, TransactionType.credited);
+      expect(transaction.transactionAmount, 100.1);
+      expect(transaction.finalAmount, 200.1);
+      expect(transaction.accountNumber, 'Bank of Baroda 1234');
+      expect(transaction.body, bobMessages.last);
+      expect(transaction.dateTime, DateTime.parse('2025-05-10 10:10:10'));
+    });
+    test('Axis single digit decimal', () {
+      var transaction = extractAxisMessages([axisMessages.last]).first;
+      expect(transaction.type, TransactionType.credited);
+      expect(transaction.transactionAmount, 100.1);
+      expect(transaction.finalAmount, 200.1);
+      expect(transaction.accountNumber, 'Axis Bank 5678');
+      expect(transaction.body, axisMessages.last);
+      expect(transaction.dateTime, DateTime.parse('2025-05-10 10:10:10'));
+    });
+    test('Cosmos single digit decimal', () {
+      var transaction = extractCosmosMessages([cosmosMessages.last]).first;
+      expect(transaction.type, TransactionType.credited);
+      expect(transaction.transactionAmount, 100.1);
+      expect(transaction.finalAmount, 200.1);
+      expect(transaction.accountNumber, 'Cosmos Bank 9999');
+      expect(transaction.body, cosmosMessages.last);
+      expect(transaction.dateTime, DateTime.parse('2025-05-10 00:00:00'));
+    });
+  });
 }

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -2,6 +2,7 @@ List<String> bobMessages = [
   'Rs.30 Credited to A/c ...7544 thru UPI/************ by **********_axl. Total Bal:Rs.92.1CR. Avlbl Amt:Rs.92.1(09-08-2023 22:40:20) - Bank of Baroda',
   'Rs.5500 withdrawn from A/c ...7544 at ATM TID ********** Ref.00000000**** Avlbl Amt:Rs.496.1(29-11-2023 16:48:04). If not used by you, call 18002584455 - Bank of Baroda',
   'Rs.20 transferred from A/c ...7544 to:UPI/************. Total Bal:Rs.3352.1CR. Avlbl Amt:Rs.3352.1(31-10-2023 21:19:22) - Bank of Baroda',
+  'Rs.100.1 Credited to A/c ...1234 thru UPI/************ by test_user. Total Bal:Rs.200.1CR. Avlbl Amt:Rs.200.1(10-05-2025 10:10:10) - Bank of Baroda',
 ];
 
 List<String> axisMessages = [
@@ -16,10 +17,12 @@ INR 50
 AARISH AHAM
 Avl Lmt INR 34985
 SMS BLOCK 3348 to 919951860002, if not you - Axis Bank''',
+  'INR 100.1 credited to A/c no. XX5678 on 10-05-25 at 10:10:10 IST. Info- NEFT/************/TEST/AXIS BANK. Avl Bal- INR 200.1 - Axis Bank',
 ];
 
 List<String> cosmosMessages = [
   'Your A/c X2345 is debited by INR. 123.45 on 23/11/23 for UPI/************/razor. A/c bal is INR. 3456.45 Cr -Cosmos Bank',
   'Your Chq  ****** of INR 10000/- is debited for A/c no XX2345 on 01-12-2023. A/c balance is INR 4567.89./-Cr.-Cosmos Bank',
   'Your A/c XX2345 is credited by INR 123.45 on 23-11-2023 for UPI-CR/************/sheet. A/c bal is INR 3456.45Cr.-Cosmos Bank',
+  'Your A/c XX9999 is credited by INR 100.1 on 10/05/25 for UPI-CR/************/test. A/c bal is INR 200.1Cr.-Cosmos Bank',
 ];


### PR DESCRIPTION
fixes #10
Enhance regex patterns to correctly extract amounts with single digit decimals across multiple message formats. Add tests to verify the functionality for different banks.