### PR TITLE
Add HDFC Bank support for transaction extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Enjoy the simplified banking experience with Messages Wallet! 🎉📱
 
 ## Supported Credit Cards
 - Axis Bank
+- HDFC Bank
 - ICICI Bank
 - Kotak Bank
 

--- a/lib/src/bank_support/extractors/extract_hdfc.dart
+++ b/lib/src/bank_support/extractors/extract_hdfc.dart
@@ -1,0 +1,118 @@
+import '../../shared/models/spending_model.dart';
+
+final _monthMap = {
+  'jan': '01',
+  'feb': '02',
+  'mar': '03',
+  'apr': '04',
+  'may': '05',
+  'jun': '06',
+  'jul': '07',
+  'aug': '08',
+  'sep': '09',
+  'oct': '10',
+  'nov': '11',
+  'dec': '12',
+};
+
+Iterable<Transaction> extractHDFCMessages(Iterable<String> hdfcMessages) =>
+    hdfcMessages
+        .map((message) {
+          if (message.contains('Online Payment of Rs.') &&
+              message.contains('was credited to your card ending')) {
+            final amountRegex = RegExp(
+              r'Online Payment of Rs\.(\d+(?:\.\d{1,2})?)',
+            );
+            final cardRegex = RegExp(r'your card ending (\d{4})');
+            final dateRegex = RegExp(r'On (\d{2})/([A-Z]{3})/(\d{4})');
+
+            final amount = amountRegex.firstMatch(message)?.group(1);
+            final cardNumber = cardRegex.firstMatch(message)?.group(1);
+            final dateMatch = dateRegex.firstMatch(message);
+
+            final day = dateMatch?.group(1);
+            final monthStr = dateMatch?.group(2);
+            final month = _monthMap[monthStr?.toLowerCase()];
+            final year = dateMatch?.group(3);
+
+            final dateTime = DateTime.tryParse('$year-$month-$day 00:00:00');
+
+            return Transaction(
+              type: TransactionType.credited,
+              transactionAmount: double.tryParse(amount ?? '') ?? 0,
+              accountNumber: cardNumber == null
+                  ? ''
+                  : 'HDFC Bank Credit Card $cardNumber',
+              body: message,
+              dateTime: dateTime ?? DateTime(0),
+              finalAmount: null,
+            );
+          }
+
+          if (message.contains('Spent Rs.') &&
+              message.contains('On HDFC Bank Card')) {
+            final amountRegex = RegExp(r'Spent Rs\.(\d+(?:\.\d{1,2})?)');
+            final cardRegex = RegExp(r'On HDFC Bank Card (\d{4})');
+            final dateRegex = RegExp(
+              r'On (\d{4})-(\d{2})-(\d{2}):(\d{2}:\d{2}:\d{2})',
+            );
+
+            final amount = amountRegex.firstMatch(message)?.group(1);
+            final cardNumber = cardRegex.firstMatch(message)?.group(1);
+            final dateMatch = dateRegex.firstMatch(message);
+
+            final year = dateMatch?.group(1);
+            final month = dateMatch?.group(2);
+            final day = dateMatch?.group(3);
+            final time = dateMatch?.group(4);
+
+            final dateTime = DateTime.tryParse('$year-$month-$day $time');
+
+            return Transaction(
+              type: TransactionType.creditCardSpent,
+              transactionAmount: double.tryParse(amount ?? '') ?? 0,
+              accountNumber: cardNumber == null
+                  ? ''
+                  : 'HDFC Bank Credit Card $cardNumber',
+              body: message,
+              dateTime: dateTime ?? DateTime(0),
+              finalAmount: null,
+            );
+          }
+
+          if (message.contains('Txn Rs.') && message.contains('by UPI')) {
+            final amountRegex = RegExp(r'Txn Rs\.(\d+(?:\.\d{1,2})?)');
+            final cardRegex = RegExp(r'On HDFC Bank Card (\d{4})');
+            final dateRegex = RegExp(r'On (\d{2})-(\d{2})');
+
+            final amount = amountRegex.firstMatch(message)?.group(1);
+            final cardNumber = cardRegex.firstMatch(message)?.group(1);
+            final dateMatch = dateRegex.firstMatch(message);
+
+            final day = dateMatch?.group(1);
+            final month = dateMatch?.group(2);
+            final year = DateTime.now().year.toString();
+
+            final dateTime = DateTime.tryParse('$year-$month-$day 00:00:00');
+
+            return Transaction(
+              type: TransactionType.creditCardSpent,
+              transactionAmount: double.tryParse(amount ?? '') ?? 0,
+              accountNumber: cardNumber == null
+                  ? ''
+                  : 'HDFC Bank Credit Card $cardNumber',
+              body: message,
+              dateTime: dateTime ?? DateTime(0),
+              finalAmount: null,
+            );
+          }
+
+          return null;
+        })
+        .whereType<Transaction>()
+        .where(
+          (element) =>
+              element.transactionAmount != 0 &&
+              element.accountNumber.isNotEmpty &&
+              element.dateTime != DateTime(0),
+        );

--- a/lib/src/shared/providers/sms_providers.dart
+++ b/lib/src/shared/providers/sms_providers.dart
@@ -6,6 +6,7 @@ import 'package:permission_handler/permission_handler.dart';
 import '../../bank_support/extractors/extract_axis.dart';
 import '../../bank_support/extractors/extract_bob.dart';
 import '../../bank_support/extractors/extract_cosmos.dart';
+import '../../bank_support/extractors/extract_hdfc.dart';
 import '../../bank_support/extractors/extract_icici.dart';
 import '../../bank_support/extractors/extract_kotak.dart';
 import '../../utils/sms_helpers.dart';
@@ -40,6 +41,9 @@ final transactionsGroupProvider = Provider<Map<String, List<Transaction>>>((
       final iciciMessages = messages.where(
         (m) => m.address.toLowerCase().contains('-icicit'),
       );
+      final hdfcMessages = messages.where(
+        (m) => m.address.toLowerCase().contains('-hdfcbk'),
+      );
       final kotakMessages = messages.where(
         (m) => m.address.toLowerCase().contains('-kotakb'),
       );
@@ -48,6 +52,7 @@ final transactionsGroupProvider = Provider<Map<String, List<Transaction>>>((
         ...extractBOBMessages(bobMessages.map((e) => e.body)),
         ...extractAxisMessages(axisMessages.map((e) => e.body)),
         ...extractCosmosMessages(cosmosMessages.map((e) => e.body)),
+        ...extractHDFCMessages(hdfcMessages.map((e) => e.body)),
         ...extractICICIMessages(iciciMessages.map((e) => e.body)),
         ...extractKotakMessages(kotakMessages.map((e) => e.body)),
       ];

--- a/lib/src/utils/sms_helpers.dart
+++ b/lib/src/utils/sms_helpers.dart
@@ -1,4 +1,11 @@
-const supportedSenders = ['axisbk', 'bobtxn', 'cosmos', 'icicit', 'kotakb'];
+const supportedSenders = [
+  'axisbk',
+  'bobtxn',
+  'cosmos',
+  'hdfcbk',
+  'icicit',
+  'kotakb',
+];
 final dltRegex = RegExp(r'^[A-Z]{2}-[A-Za-z0-9]{6}(?:-[ST])?$');
 final _allDigitsRegex = RegExp(r'^\d+$');
 

--- a/test/extract_test.dart
+++ b/test/extract_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:messages_wallet/src/bank_support/extractors/extract_axis.dart';
 import 'package:messages_wallet/src/bank_support/extractors/extract_bob.dart';
 import 'package:messages_wallet/src/bank_support/extractors/extract_cosmos.dart';
+import 'package:messages_wallet/src/bank_support/extractors/extract_hdfc.dart';
 import 'package:messages_wallet/src/bank_support/extractors/extract_icici.dart';
 import 'package:messages_wallet/src/bank_support/extractors/extract_kotak.dart';
 import 'package:messages_wallet/src/shared/models/spending_model.dart';
@@ -302,6 +303,44 @@ void main() {
       expect(transaction.accountNumber, 'Cosmos Bank 9999');
       expect(transaction.body, cosmosMessages['cosmos_single_decimal']);
       expect(transaction.dateTime, DateTime.parse('2025-05-10 00:00:00'));
+    });
+  });
+
+  group('HDFC Extract', () {
+    test('UPI debit (multi-line, Txn Rs.)', () {
+      final transaction = extractHDFCMessages([
+        hdfcMessages['hdfc_upi_debit']!,
+      ]).first;
+      expect(transaction.type, TransactionType.creditCardSpent);
+      expect(transaction.transactionAmount, 60.00);
+      expect(transaction.finalAmount, isNull);
+      expect(transaction.accountNumber, 'HDFC Bank Credit Card 1885');
+      expect(transaction.body, hdfcMessages['hdfc_upi_debit']);
+      expect(transaction.dateTime, DateTime(DateTime.now().year, 5, 8));
+    });
+
+    test('online payment credited (VM-HDFCBK-S)', () {
+      final transaction = extractHDFCMessages([
+        hdfcMessages['hdfc_payment']!,
+      ]).first;
+      expect(transaction.type, TransactionType.credited);
+      expect(transaction.transactionAmount, 11713);
+      expect(transaction.finalAmount, isNull);
+      expect(transaction.accountNumber, 'HDFC Bank Credit Card 1885');
+      expect(transaction.body, hdfcMessages['hdfc_payment']);
+      expect(transaction.dateTime, DateTime.parse('2026-04-29 00:00:00'));
+    });
+
+    test('merchant spent (single-line, Spent Rs.)', () {
+      final transaction = extractHDFCMessages([
+        hdfcMessages['hdfc_spent']!,
+      ]).first;
+      expect(transaction.type, TransactionType.creditCardSpent);
+      expect(transaction.transactionAmount, 1577);
+      expect(transaction.finalAmount, isNull);
+      expect(transaction.accountNumber, 'HDFC Bank Credit Card 0323');
+      expect(transaction.body, hdfcMessages['hdfc_spent']);
+      expect(transaction.dateTime, DateTime.parse('2026-04-29 23:25:03'));
     });
   });
 

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -58,6 +58,15 @@ Map<String, String> iciciMessages = {
       'Payment of Rs 3,155.55 has been received on your ICICI Bank Credit Card XX7004 through Bharat Bill Payment System on 28-MAR-25.',
 };
 
+Map<String, String> hdfcMessages = {
+  'hdfc_upi_debit':
+      'Txn Rs.60.00\nOn HDFC Bank Card 1885\nAt 9999999999@ybl\nby UPI 123456789012\nOn 08-05\nNot You?\nCall 18002586161/SMS BLOCK CC 1885 to 7308080808\n',
+  'hdfc_payment':
+      'HDFC Bank Cardmember, Online Payment of Rs.11713 vide Ref# XXXXXXXXXX was credited to your card ending 1885 On 29/APR/2026_value Date 29/APR/2026',
+  'hdfc_spent':
+      'Spent Rs.1577 On HDFC Bank Card 0323 At MERCHANT On 2026-04-29:23:25:03.Not You? To Block+Reissue Call 18002586161/SMS BLOCK CC 0323 to 7308080808',
+};
+
 Map<String, String> kotakMessages = {
   'kotak_spent_vm':
       'INR 500 spent on Kotak Bank Card x6746 on 27-APR-2025 at MERCHANT. Avl limit INR 29500. For dispute, https://kotak.com/XXXXXXXXXX',


### PR DESCRIPTION
Implement support for extracting transactions from HDFC Bank messages, including online payments, UPI debits, and merchant spends. Update the list of supported banks and add corresponding tests for validation.