### PR TITLE
Add support for credit card reversal transactions in HDFC message extraction

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,9 @@
             ".github/ISSUE_TEMPLATE/bug_report.yml",
             ".github/ISSUE_TEMPLATE/feature_request.yml"
         ]
+    },
+    "chat.tools.terminal.autoApprove": {
+        "dart format": true,
+        "flutter analyze": true
     }
 }

--- a/lib/src/bank_support/extractors/extract_hdfc.dart
+++ b/lib/src/bank_support/extractors/extract_hdfc.dart
@@ -80,6 +80,37 @@ Iterable<Transaction> extractHDFCMessages(Iterable<String> hdfcMessages) =>
             );
           }
 
+          if (message.contains('Transaction Reversed!') &&
+              message.contains('HDFC Bank CREDIT Card')) {
+            final amountRegex = RegExp(r'Amt:\s*Rs\.(\d+(?:\.\d{1,2})?)');
+            final cardRegex = RegExp(r'HDFC Bank CREDIT Card [Xx]{2}(\d{4})');
+            final dateRegex = RegExp(
+              r'On (\d{4})-(\d{2})-(\d{2}):(\d{2}:\d{2}:\d{2})',
+            );
+
+            final amount = amountRegex.firstMatch(message)?.group(1);
+            final cardNumber = cardRegex.firstMatch(message)?.group(1);
+            final dateMatch = dateRegex.firstMatch(message);
+
+            final year = dateMatch?.group(1);
+            final month = dateMatch?.group(2);
+            final day = dateMatch?.group(3);
+            final time = dateMatch?.group(4);
+
+            final dateTime = DateTime.tryParse('$year-$month-$day $time');
+
+            return Transaction(
+              type: TransactionType.creditCardReversed,
+              transactionAmount: double.tryParse(amount ?? '') ?? 0,
+              accountNumber: cardNumber == null
+                  ? ''
+                  : 'HDFC Bank Credit Card $cardNumber',
+              body: message,
+              dateTime: dateTime ?? DateTime(0),
+              finalAmount: null,
+            );
+          }
+
           if (message.contains('Txn Rs.') && message.contains('by UPI')) {
             final amountRegex = RegExp(r'Txn Rs\.(\d+(?:\.\d{1,2})?)');
             final cardRegex = RegExp(r'On HDFC Bank Card (\d{4})');

--- a/lib/src/bank_support/view/bank_support_screen.dart
+++ b/lib/src/bank_support/view/bank_support_screen.dart
@@ -18,7 +18,7 @@ class BankSupportScreen extends ConsumerStatefulWidget {
 
 class _BankSupportScreenState extends ConsumerState<BankSupportScreen> {
   final Set<SmsData> _selectedMessages = {};
-  bool _hideSupported = false;
+  bool _showSupported = false;
 
   List<SmsData> _messagesForSender(
     String key,
@@ -31,7 +31,7 @@ class _BankSupportScreenState extends ConsumerState<BankSupportScreen> {
     Set<String> transactionBodies,
   ) {
     final msgs = _messagesForSender(key, filteredGroups);
-    if (_hideSupported && isSupported(key)) {
+    if (!_showSupported && isSupported(key)) {
       return msgs.where((m) => !transactionBodies.contains(m.body)).toList();
     }
     return msgs;
@@ -125,13 +125,13 @@ class _BankSupportScreenState extends ConsumerState<BankSupportScreen> {
                     child: Row(
                       children: [
                         Text(
-                          'Hide supported messages',
+                          'Show supported messages',
                           style: Theme.of(context).textTheme.bodySmall,
                         ),
                         const Spacer(),
                         Switch.adaptive(
-                          value: _hideSupported,
-                          onChanged: (v) => setState(() => _hideSupported = v),
+                          value: _showSupported,
+                          onChanged: (v) => setState(() => _showSupported = v),
                         ),
                       ],
                     ),
@@ -155,7 +155,7 @@ class _BankSupportScreenState extends ConsumerState<BankSupportScreen> {
                               ),
                               selectedMessages: _selectedMessages,
                               transactionBodies: transactionBodies,
-                              hideSupported: _hideSupported,
+                              showSupported: _showSupported,
                               onMessageToggled: (msg, selected) {
                                 setState(() {
                                   if (selected) {
@@ -182,7 +182,7 @@ class _SenderExpansionTile extends StatelessWidget {
     required this.messages,
     required this.selectedMessages,
     required this.transactionBodies,
-    required this.hideSupported,
+    required this.showSupported,
     required this.onMessageToggled,
   });
 
@@ -190,7 +190,7 @@ class _SenderExpansionTile extends StatelessWidget {
   final List<SmsData> messages;
   final Set<SmsData> selectedMessages;
   final Set<String> transactionBodies;
-  final bool hideSupported;
+  final bool showSupported;
   final void Function(SmsData msg, bool selected) onMessageToggled;
 
   @override
@@ -237,7 +237,7 @@ class _SenderExpansionTile extends StatelessWidget {
                     isSelected: selectedMessages.contains(msg),
                     isTransaction:
                         supported && transactionBodies.contains(msg.body),
-                    hideSupported: hideSupported,
+                    showSupported: showSupported,
                     onChanged: (v) => onMessageToggled(msg, v ?? false),
                   ),
               ],
@@ -253,7 +253,7 @@ class _MessageCheckboxTile extends StatelessWidget {
     required this.supported,
     required this.isSelected,
     required this.isTransaction,
-    required this.hideSupported,
+    required this.showSupported,
     required this.onChanged,
   });
 
@@ -262,12 +262,12 @@ class _MessageCheckboxTile extends StatelessWidget {
   final bool supported;
   final bool isSelected;
   final bool isTransaction;
-  final bool hideSupported;
+  final bool showSupported;
   final ValueChanged<bool?> onChanged;
 
   @override
   Widget build(BuildContext context) {
-    final showChip = supported && (isTransaction || !hideSupported);
+    final showChip = supported && (isTransaction || showSupported);
     return CheckboxListTile(
       value: isSelected,
       onChanged: onChanged,

--- a/test/extract_test.dart
+++ b/test/extract_test.dart
@@ -413,6 +413,18 @@ void main() {
       expect(transaction.body, hdfcMessages['hdfc_spent']);
       expect(transaction.dateTime, DateTime.parse('2026-04-29 23:25:03'));
     });
+
+    test('credit card reversal (Transaction Reversed!)', () {
+      final transaction = extractHDFCMessages([
+        hdfcMessages['hdfc_reversed']!,
+      ]).first;
+      expect(transaction.type, TransactionType.creditCardReversed);
+      expect(transaction.transactionAmount, 131.15);
+      expect(transaction.finalAmount, isNull);
+      expect(transaction.accountNumber, 'HDFC Bank Credit Card 0323');
+      expect(transaction.body, hdfcMessages['hdfc_reversed']);
+      expect(transaction.dateTime, DateTime.parse('2026-05-12 10:58:57'));
+    });
   });
 
   group('Kotak Extract', () {

--- a/test/test_data.dart
+++ b/test/test_data.dart
@@ -75,6 +75,8 @@ Map<String, String> hdfcMessages = {
       'HDFC Bank Cardmember, Online Payment of Rs.11713 vide Ref# XXXXXXXXXX was credited to your card ending 1885 On 29/APR/2026_value Date 29/APR/2026',
   'hdfc_spent':
       'Spent Rs.1577 On HDFC Bank Card 0323 At MERCHANT On 2026-04-29:23:25:03.Not You? To Block+Reissue Call 18002586161/SMS BLOCK CC 0323 to 7308080808',
+  'hdfc_reversed':
+      'Transaction Reversed!On HDFC Bank CREDIT Card xx0323 Amt: Rs.131.15 By MERCHANT On 2026-05-12:10:58:57',
 };
 
 Map<String, String> kotakMessages = {


### PR DESCRIPTION
Implement support for extracting credit card reversal transactions from HDFC messages and update the corresponding tests. Adjust the bank support message toggle to show supported messages instead of hiding them.